### PR TITLE
Add dynamic product loading and scroll-activated footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,6 +69,10 @@
             <!-- Products will be injected here by JavaScript -->
         </section>
     </main>
+    <!-- Footer -->
+    <footer id="page-footer" class="hidden bg-gray-800 text-white text-center py-4">
+        <p>&copy; 2024 MercadoConfianza. Todos los derechos reservados.</p>
+    </footer>
 
     <!-- Credit Simulator Modal -->
     <div id="credit-modal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50 hidden">
@@ -127,20 +131,7 @@
 
     <script>
         document.addEventListener('DOMContentLoaded', () => {
-            const products = [
-                { id: 1, name: 'Celular Avanzado X1', price: 1200000, category: 'celulares', image: 'https://placehold.co/400x400/34d399/ffffff?text=Celular+X1' },
-                { id: 2, name: 'Refrigerador Familiar', price: 2500000, category: 'linea blanca', image: 'https://placehold.co/400x400/93c5fd/ffffff?text=Refrigerador' },
-                { id: 3, name: 'TV Smart 55" 4K', price: 1800000, category: 'linea marron', image: 'https://placehold.co/400x400/f87171/ffffff?text=TV+55"' },
-                { id: 4, name: 'Laptop Pro 14"', price: 3200000, category: 'tecnologia', image: 'https://placehold.co/400x400/facc15/ffffff?text=Laptop+Pro' },
-                { id: 5, name: 'Lavadora Carga Frontal', price: 1950000, category: 'linea blanca', image: 'https://placehold.co/400x400/93c5fd/ffffff?text=Lavadora' },
-                { id: 6, name: 'Smartphone Económico', price: 750000, category: 'celulares', image: 'https://placehold.co/400x400/34d399/ffffff?text=Celular+Eco' },
-                { id: 7, name: 'Sofá 3 Puestos', price: 980000, category: 'hogar', image: 'https://placehold.co/400x400/c084fc/ffffff?text=Sofá' },
-                { id: 8, name: 'Audífonos Inalámbricos', price: 350000, category: 'tecnologia', image: 'https://placehold.co/400x400/facc15/ffffff?text=Audífonos' },
-                { id: 9, name: 'Microondas Digital', price: 450000, category: 'linea blanca', image: 'https://placehold.co/400x400/93c5fd/ffffff?text=Microondas' },
-                { id: 10, name: 'Barra de Sonido', price: 600000, category: 'linea marron', image: 'https://placehold.co/400x400/f87171/ffffff?text=Soundbar' },
-                { id: 11, name: 'Tablet 10"', price: 890000, category: 'tecnologia', image: 'https://placehold.co/400x400/facc15/ffffff?text=Tablet' },
-                { id: 12, name: 'Juego de Comedor', price: 1300000, category: 'hogar', image: 'https://placehold.co/400x400/c084fc/ffffff?text=Comedor' },
-            ];
+            let products = [];
 
             const productGrid = document.getElementById('product-grid');
             const categoryFilters = document.getElementById('category-filters');
@@ -158,6 +149,14 @@
             const costoTotal = document.getElementById('costo-total');
             
             let currentProductPrice = 0;
+            const footer = document.getElementById("page-footer");
+            let footerShown = false;
+            window.addEventListener("scroll", () => {
+                if (!footerShown && window.scrollY > 0) {
+                    footer.classList.remove("hidden");
+                    footerShown = true;
+                }
+            });
 
             function formatCurrency(value) {
                 return new Intl.NumberFormat('es-CO', { style: 'currency', currency: 'COP', minimumFractionDigits: 0 }).format(value);
@@ -248,9 +247,13 @@
 
             closeModalBtn.addEventListener('click', () => modal.classList.add('hidden'));
             cuotasSlider.addEventListener('input', calculateCredit);
+            fetch("products.json")
+                .then(response => response.json())
+                .then(data => {
+                    products = data;
+                    renderProducts(products);
+                });
             
-            // Initial Render
-            renderProducts(products);
         });
     </script>
 </body>

--- a/products.json
+++ b/products.json
@@ -1,0 +1,14 @@
+[
+    {"id": 1, "name": "Celular Avanzado X1", "price": 1200000, "category": "celulares", "image": "https://placehold.co/400x400/34d399/ffffff?text=Celular+X1"},
+    {"id": 2, "name": "Refrigerador Familiar", "price": 2500000, "category": "linea blanca", "image": "https://placehold.co/400x400/93c5fd/ffffff?text=Refrigerador"},
+    {"id": 3, "name": "TV Smart 55\" 4K", "price": 1800000, "category": "linea marron", "image": "https://placehold.co/400x400/f87171/ffffff?text=TV+55"},
+    {"id": 4, "name": "Laptop Pro 14\"", "price": 3200000, "category": "tecnologia", "image": "https://placehold.co/400x400/facc15/ffffff?text=Laptop+Pro"},
+    {"id": 5, "name": "Lavadora Carga Frontal", "price": 1950000, "category": "linea blanca", "image": "https://placehold.co/400x400/93c5fd/ffffff?text=Lavadora"},
+    {"id": 6, "name": "Smartphone Económico", "price": 750000, "category": "celulares", "image": "https://placehold.co/400x400/34d399/ffffff?text=Celular+Eco"},
+    {"id": 7, "name": "Sofá 3 Puestos", "price": 980000, "category": "hogar", "image": "https://placehold.co/400x400/c084fc/ffffff?text=Sof%C3%A1"},
+    {"id": 8, "name": "Audífonos Inalámbricos", "price": 350000, "category": "tecnologia", "image": "https://placehold.co/400x400/facc15/ffffff?text=Aud%C3%ADfonos"},
+    {"id": 9, "name": "Microondas Digital", "price": 450000, "category": "linea blanca", "image": "https://placehold.co/400x400/93c5fd/ffffff?text=Microondas"},
+    {"id": 10, "name": "Barra de Sonido", "price": 600000, "category": "linea marron", "image": "https://placehold.co/400x400/f87171/ffffff?text=Soundbar"},
+    {"id": 11, "name": "Tablet 10\"", "price": 890000, "category": "tecnologia", "image": "https://placehold.co/400x400/facc15/ffffff?text=Tablet"},
+    {"id": 12, "name": "Juego de Comedor", "price": 1300000, "category": "hogar", "image": "https://placehold.co/400x400/c084fc/ffffff?text=Comedor"}
+]


### PR DESCRIPTION
## Summary
- load products from a new `products.json` file instead of hardcoding them in HTML
- add a hidden footer that becomes visible after the first scroll

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685a06d1a4c08326883e72e2410c4f88