### PR TITLE
Implement lazy image loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -262,7 +262,7 @@
             function createProductCard(product, cta) {
                 return `
                     <div class="product-card bg-white rounded-lg shadow-md overflow-hidden flex flex-col">
-                        <img src="${product.image}" alt="${product.name}" class="w-full h-48 object-cover">
+                        <img data-src="${product.image}" alt="${product.name}" class="lazy w-full h-48 object-cover bg-gray-200" width="400" height="400" loading="lazy">
                         <div class="p-4 flex flex-col flex-grow">
                             <h4 class="text-md font-semibold text-gray-800 flex-grow">${product.name}</h4>
                             <p class="text-lg font-bold text-gray-900 mt-2">${formatCurrency(product.price)}</p>
@@ -295,6 +295,7 @@
                             block.appendChild(grid);
                             mitosSection.appendChild(block);
                         });
+                        setupLazyLoading();
                     }
                     mitosSection.classList.remove('hidden');
                     productGrid.classList.add('hidden');
@@ -317,12 +318,27 @@
                 return new Intl.NumberFormat('es-CO', { style: 'currency', currency: 'COP', minimumFractionDigits: 0 }).format(value);
             }
 
+            function setupLazyLoading() {
+                const lazyImages = document.querySelectorAll('img.lazy');
+                const observer = new IntersectionObserver((entries, obs) => {
+                    entries.forEach(entry => {
+                        if (entry.isIntersecting) {
+                            const img = entry.target;
+                            img.src = img.dataset.src;
+                            img.classList.remove('lazy');
+                            obs.unobserve(img);
+                        }
+                    });
+                });
+                lazyImages.forEach(img => observer.observe(img));
+            }
+
             function renderProducts(filteredProducts) {
                 productGrid.innerHTML = '';
                 filteredProducts.forEach(product => {
                     const productCard = `
                         <div class="product-card bg-white rounded-lg shadow-md overflow-hidden flex flex-col">
-                            <img src="${product.image}" alt="${product.name}" class="w-full h-48 object-cover">
+                            <img data-src="${product.image}" alt="${product.name}" class="lazy w-full h-48 object-cover bg-gray-200" width="400" height="400" loading="lazy">
                             <div class="p-4 flex flex-col flex-grow">
                                 <h4 class="text-md font-semibold text-gray-800 flex-grow">${product.name}</h4>
                                 <p class="text-lg font-bold text-gray-900 mt-2">${formatCurrency(product.price)}</p>
@@ -334,6 +350,7 @@
                     `;
                     productGrid.innerHTML += productCard;
                 });
+                setupLazyLoading();
             }
 
             function calculateCredit() {


### PR DESCRIPTION
## Summary
- load product images lazily using IntersectionObserver
- show gray placeholders to preserve layout during loading

## Testing
- `npm test` *(fails: could not find package.json)*
- `npx htmlhint index.html` *(fails: canceled)*

------
https://chatgpt.com/codex/tasks/task_e_685a22fec9bc832693877baa49dbfb08